### PR TITLE
Fixed an error I made previously in my algorithm

### DIFF
--- a/_ctoApps/caesar/src/caesar/caesar.js
+++ b/_ctoApps/caesar/src/caesar/caesar.js
@@ -18,7 +18,7 @@ String.prototype.encrypt = function (key, b_encrypt, b_block_of_five, alphabet, 
 				const new_index = (index + key) % alphabet.length
 				new_character = alphabet[new_index]
 			} else {
-				new_index = (index - key) % alphabet.length
+				const new_index = (index - key) % alphabet.length
 				new_character = alphabet[new_index]
 			}
 		}


### PR DESCRIPTION
When decoding a message while being in a `use strict` context could result in an error. This is now fixed.